### PR TITLE
Refactored code to add Predefined quick reply feature in public/src/modules/quickreply.js

### DIFF
--- a/public/src/modules/quickreply.js
+++ b/public/src/modules/quickreply.js
@@ -87,6 +87,10 @@ define('quickreply', [
 		const quickReplyMessage = quickReplyContainer.find('.quickreply-message');
 	
 		quickReplyMessage.find('textarea').after(suggestedResponsesHtml);
+		
+		$(document).on('click', '.quickreply-suggested-response', function () {
+			console.log($(this)["0"].innerText);
+		});
 
 		let ready = true;
 		components.get('topic/quickreply/button').on('click', function (e) {

--- a/public/src/modules/quickreply.js
+++ b/public/src/modules/quickreply.js
@@ -85,11 +85,11 @@ define('quickreply', [
 
 		const quickReplyContainer = $('[component="topic/quickreply/container"]');
 		const quickReplyMessage = quickReplyContainer.find('.quickreply-message');
-	
+
 		quickReplyMessage.find('textarea').after(suggestedResponsesHtml);
-		
+
 		$(document).on('click', '.quickreply-suggested-response', function () {
-			const buttonText = $(this)["0"].innerText;
+			const buttonText = $(this)['0'].innerText;
 			const textarea = components.get('topic/quickreply/text');
 
 			const currentText = textarea.val();
@@ -100,9 +100,8 @@ define('quickreply', [
 				textarea.val(currentText + '\n' + buttonText);
 			}
 
-			textarea[0].selectionStart = 
-			textarea[0].selectionEnd = 
-			textarea.val().length;
+			textarea[0].selectionStart = textarea.val().length;
+			textarea[0].selectionEnd = textarea.val().length;
 
 			textarea.trigger('input');
 		});

--- a/public/src/modules/quickreply.js
+++ b/public/src/modules/quickreply.js
@@ -50,6 +50,18 @@ define('quickreply', [
 			},
 		});
 
+		const suggestedResponsesHtml = `
+		<div class="quickreply-suggested-responses">
+		  <span class="quickreply-suggested-response">Button 1</span>
+		  <span class="quickreply-suggested-response">Button 2</span>
+		</div>
+	  `;
+
+		const quickReplyContainer = $('[component="topic/quickreply/container"]');
+		const quickReplyMessage = quickReplyContainer.find('.quickreply-message');
+	
+		quickReplyMessage.find('textarea').after(suggestedResponsesHtml);
+
 		let ready = true;
 		components.get('topic/quickreply/button').on('click', function (e) {
 			e.preventDefault();

--- a/public/src/modules/quickreply.js
+++ b/public/src/modules/quickreply.js
@@ -97,7 +97,7 @@ define('quickreply', [
 			if (!currentText.trim()) {
 				textarea.val(buttonText);
 			} else {
-				console.log(buttonText);
+				textarea.val(currentText + '\n' + buttonText);
 			}
 		});
 

--- a/public/src/modules/quickreply.js
+++ b/public/src/modules/quickreply.js
@@ -103,6 +103,8 @@ define('quickreply', [
 			textarea[0].selectionStart = 
 			textarea[0].selectionEnd = 
 			textarea.val().length;
+
+			textarea.trigger('input');
 		});
 
 		let ready = true;

--- a/public/src/modules/quickreply.js
+++ b/public/src/modules/quickreply.js
@@ -76,10 +76,10 @@ define('quickreply', [
 
 		const suggestedResponsesHtml = `
 		<div class="quickreply-suggested-responses">
-		  <span class="quickreply-suggested-response">Button 1</span>
-		  <span class="quickreply-suggested-response">Button 2</span>
-		  <span class="quickreply-suggested-response">Button 3</span>
-		  <span class="quickreply-suggested-response">Button 4</span>
+		  <span class="quickreply-suggested-response">Thank you!</span>
+		  <span class="quickreply-suggested-response">Makes sense.</span>
+		  <span class="quickreply-suggested-response">Sounds Good!</span>
+		  <span class="quickreply-suggested-response">Could you clarify further?</span>
 		</div>
 	  `;
 

--- a/public/src/modules/quickreply.js
+++ b/public/src/modules/quickreply.js
@@ -67,6 +67,9 @@ define('quickreply', [
           		cursor: pointer;
           		color: #1a237e;
         	}
+	        .quickreply-suggested-response:hover {
+				background-color: #c5cae9;
+			}
 		</style>`;
 
 		$('head').append(style);

--- a/public/src/modules/quickreply.js
+++ b/public/src/modules/quickreply.js
@@ -99,6 +99,10 @@ define('quickreply', [
 			} else {
 				textarea.val(currentText + '\n' + buttonText);
 			}
+
+			textarea[0].selectionStart = 
+			textarea[0].selectionEnd = 
+			textarea.val().length;
 		});
 
 		let ready = true;

--- a/public/src/modules/quickreply.js
+++ b/public/src/modules/quickreply.js
@@ -93,6 +93,12 @@ define('quickreply', [
 			const textarea = components.get('topic/quickreply/text');
 
 			const currentText = textarea.val();
+
+			if (!currentText.trim()) {
+				textarea.val(buttonText);
+			} else {
+				console.log(buttonText);
+			}
 		});
 
 		let ready = true;

--- a/public/src/modules/quickreply.js
+++ b/public/src/modules/quickreply.js
@@ -50,6 +50,17 @@ define('quickreply', [
 			},
 		});
 
+		const style = `
+		<style>
+		  .quickreply-suggested-responses {
+			margin-top: 5px;
+			display: flex;
+			flex-wrap: wrap;
+		  }
+		</style>`;
+
+		$('head').append(style);
+
 		const suggestedResponsesHtml = `
 		<div class="quickreply-suggested-responses">
 		  <span class="quickreply-suggested-response">Button 1</span>

--- a/public/src/modules/quickreply.js
+++ b/public/src/modules/quickreply.js
@@ -52,11 +52,21 @@ define('quickreply', [
 
 		const style = `
 		<style>
-		  .quickreply-suggested-responses {
-			margin-top: 5px;
-			display: flex;
-			flex-wrap: wrap;
-		  }
+		  	.quickreply-suggested-responses {
+				margin-top: 5px;
+				display: flex;
+				flex-wrap: wrap;
+		  	}
+			.quickreply-suggested-response {
+          		display: inline-block;
+          		padding: 5px 10px;
+          		margin-right: 5px;
+          		margin-bottom: 5px;
+          		background-color: #e0e7ff;
+          		border-radius: 5px;
+          		cursor: pointer;
+          		color: #1a237e;
+        	}
 		</style>`;
 
 		$('head').append(style);

--- a/public/src/modules/quickreply.js
+++ b/public/src/modules/quickreply.js
@@ -78,6 +78,8 @@ define('quickreply', [
 		<div class="quickreply-suggested-responses">
 		  <span class="quickreply-suggested-response">Button 1</span>
 		  <span class="quickreply-suggested-response">Button 2</span>
+		  <span class="quickreply-suggested-response">Button 3</span>
+		  <span class="quickreply-suggested-response">Button 4</span>
 		</div>
 	  `;
 

--- a/public/src/modules/quickreply.js
+++ b/public/src/modules/quickreply.js
@@ -90,6 +90,8 @@ define('quickreply', [
 		
 		$(document).on('click', '.quickreply-suggested-response', function () {
 			const buttonText = $(this)["0"].innerText;
+			const textarea = components.get('topic/quickreply/text');
+			console.log(textarea.val());
 		});
 
 		let ready = true;

--- a/public/src/modules/quickreply.js
+++ b/public/src/modules/quickreply.js
@@ -89,7 +89,7 @@ define('quickreply', [
 		quickReplyMessage.find('textarea').after(suggestedResponsesHtml);
 		
 		$(document).on('click', '.quickreply-suggested-response', function () {
-			console.log($(this)["0"].innerText);
+			const buttonText = $(this)["0"].innerText;
 		});
 
 		let ready = true;

--- a/public/src/modules/quickreply.js
+++ b/public/src/modules/quickreply.js
@@ -91,7 +91,8 @@ define('quickreply', [
 		$(document).on('click', '.quickreply-suggested-response', function () {
 			const buttonText = $(this)["0"].innerText;
 			const textarea = components.get('topic/quickreply/text');
-			console.log(textarea.val());
+
+			const currentText = textarea.val();
 		});
 
 		let ready = true;


### PR DESCRIPTION
This pull request resolves issues 47 and 50 as it will now add the predefined quick reply feature to the frontend and backend.

I did this by adding html code for buttons which represent predefined quick reply messages. I also stylized these buttons by adding an in-line html style element. Then created an event listener for when any of the buttons are clicked. If this event listener is trigger the appropriate quick reply will be then added to the text box.

Changes were also tested using the npm run lint and npm run test commands.

Resolves #47 
Resolves #50 
With the changes also made by Aadi now Resolves #45 