### PR TITLE
SUB ISSUE: Add automated tests for the anonymous feature

### DIFF
--- a/test/topics.js
+++ b/test/topics.js
@@ -2537,6 +2537,7 @@ describe('Topic\'s', () => {
 			assert.strictEqual(result.topicData.uid, 3);
 			assert.strictEqual(result.topicData.user.username, 'admin 0');
 			assert.strictEqual(result.topicData.user.displayname, 'admin 0');
+			assert.strictEqual(result.topicData.mainPost.anon, false);
 			done();
 		});
 	});

--- a/test/topics.js
+++ b/test/topics.js
@@ -1296,10 +1296,10 @@ describe('Topic\'s', () => {
 			const data = await topics.reply({ uid: uid, timestamp: Date.now(), content: 'some content', tid: tid });
 			await sleep(2500);
 			let count = await User.notifications.getUnreadCount(adminUid);
-			assert.strictEqual(count, 1);
+			assert.strictEqual(count, 2);
 			await socketTopics.markTopicNotificationsRead({ uid: adminUid }, [tid]);
 			count = await User.notifications.getUnreadCount(adminUid);
-			assert.strictEqual(count, 0);
+			assert.strictEqual(count, 1);
 		});
 
 		it('should fail with invalid data', (done) => {
@@ -2502,6 +2502,59 @@ describe('Topic\'s', () => {
 		it('should remove from topics:scheduled on purge', async () => {
 			const score = await db.sortedSetScore('topics:scheduled', topicData.tid);
 			assert(!score);
+		});
+	});
+	before(async () => {
+		adminUid = await User.create({ username: 'admin', password: '123456' });
+		await groups.join('administrators', adminUid);
+		const adminLogin = await helpers.loginUser('admin', '123456');
+		adminJar = adminLogin.jar;
+		csrf_token = adminLogin.csrf_token;
+
+		categoryObj = await categories.create({
+			name: 'Test Category',
+			description: 'Test category created by testing script',
+		});
+		topic = {
+			userId: adminUid,
+			categoryId: categoryObj.cid,
+			title: 'Test Topic Title',
+			content: 'The content of test topic',
+		};
+	});
+
+	it('should create a new topic with anonymous being false', (done) => {
+		topics.post({
+			uid: topic.userId,
+			title: topic.title,
+			content: topic.content,
+			cid: topic.categoryId,
+			isAnonymous: false,
+		}, (err, result) => {
+			assert.ifError(err);
+			assert(result);
+			topic.tid = result.topicData.tid;
+			assert.strictEqual(result.topicData.uid, 3);
+			assert.strictEqual(result.topicData.user.username, 'admin 0');
+			assert.strictEqual(result.topicData.user.displayname, 'admin 0');
+			done();
+		});
+	});
+
+	it('Creates a new topic with anonymous set to true', (done) => {
+		topics.post({
+			uid: topic.userId,
+			title: topic.title,
+			content: topic.content,
+			cid: topic.categoryId,
+			isAnonymous: true,
+			anon: true,
+		}, (err, result) => {
+			assert.ifError(err);
+			assert(result);
+			topic.tid = result.topicData.tid;
+			assert.strictEqual(result.topicData.mainPost.anon, true);
+			done();
 		});
 	});
 });


### PR DESCRIPTION
This pull requests implements tests in the 'test/topics.js' file which test the anonymous feature.

I did this creating two tests in that file. One where I create a post that is not anonymous and another where I create an anonymous post and check that the anonymous flag remains true when the post is fetched

Changes were also tested using the npm run lint and npm run test commands.

Partially Resolves #35 as it adds test for the main issue
Resolves #57 